### PR TITLE
Fix syntax issue.

### DIFF
--- a/Templating/ImageLocator.php
+++ b/Templating/ImageLocator.php
@@ -57,6 +57,6 @@ class ImageLocator implements ImageLocatorInterface
      */
     private static function getImageDir($rootDir)
     {
-        return $rootDir.'/Resources/public'.is_dir($rootDir.'/Resources/public/images') ? '/images/' : '/img/';
+        return $rootDir.'/Resources/public'.(is_dir($rootDir.'/Resources/public/images') ? '/images/' : '/img/');
     }
 }


### PR DESCRIPTION
String concatenation operation has priority over conditional operator. Without parenthesis, the expression was interpreted as:
($rootDir.'/Resources/public'.is_dir($rootDir.'/Resources/public/images')) ? '/images/' : '/img/'

See http://php.net/manual/en/language.operators.precedence.php